### PR TITLE
Defer template gallery updates with useDeferredValue

### DIFF
--- a/packages/demo/src/components/template-gallery.tsx
+++ b/packages/demo/src/components/template-gallery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react' // Added useEffect and useRef
+import React, { useDeferredValue, useEffect, useRef } from 'react' // Added useDeferredValue
 import {
   Card,
   CardBody,
@@ -78,6 +78,14 @@ export const TemplateGallery: React.FC = () => {
     advancedOptions: _advancedOptions // Same as above
   } = qrConfigStoreState
 
+  // Defer values used for gallery generation so preview rendering has higher priority
+  const deferredTemplateId = useDeferredValue(storeSelectedTemplateId)
+  const deferredBorderId = useDeferredValue(storeSelectedBorderId)
+  const deferredStyleId = useDeferredValue(storeSelectedStyleId)
+  const deferredImageId = useDeferredValue(storeSelectedImageId)
+  const deferredTextTemplateId = useDeferredValue(storeSelectedTextTemplateId)
+  const deferredQrData = useDeferredValue(qrData)
+
   const templateRefs = React.useRef<Record<string, HTMLDivElement | null>>({})
   const activeCategory = galleryCategories.find(cat => cat.id === activeGalleryTabId)
 
@@ -120,18 +128,18 @@ export const TemplateGallery: React.FC = () => {
           if (el) {
             // el.innerHTML = ''
             const baseImage =
-              storeSelectedImageId === 'none'
+              deferredImageId === 'none'
                 ? null
-                : imageOptions.find(img => img.id === storeSelectedImageId)?.value || null
+                : imageOptions.find(img => img.id === deferredImageId)?.value || null
 
             const options = {
               element: el,
-              data: qrData,
-              templateId: storeSelectedTemplateId,
-              styleId: storeSelectedStyleId,
-              borderId: storeSelectedBorderId,
+              data: deferredQrData,
+              templateId: deferredTemplateId,
+              styleId: deferredStyleId,
+              borderId: deferredBorderId,
               image: baseImage,
-              textId: storeSelectedTextTemplateId,
+              textId: deferredTextTemplateId,
               options: { isResponsive: false }
             }
 
@@ -201,12 +209,12 @@ export const TemplateGallery: React.FC = () => {
     void generateTemplates()
   }, [
     activeGalleryTabId,
-    qrData,
-    storeSelectedTemplateId,
-    storeSelectedBorderId,
-    storeSelectedStyleId,
-    storeSelectedImageId,
-    storeSelectedTextTemplateId,
+    deferredQrData,
+    deferredTemplateId,
+    deferredBorderId,
+    deferredStyleId,
+    deferredImageId,
+    deferredTextTemplateId,
     activeCategory
   ])
 


### PR DESCRIPTION
## Summary
- prioritize main QR preview by deferring gallery renders
- use `useDeferredValue` in `TemplateGallery` to lag expensive QR generation

## Testing
- `npm run format`
- `npm run lint`