### PR TITLE
Implement local storage persistence and share links

### DIFF
--- a/packages/demo/src/components/qr-code-builder.tsx
+++ b/packages/demo/src/components/qr-code-builder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Button, Card, CardBody, Input, Tab, Tabs } from '@heroui/react'
 import { useAtomValue } from 'jotai'
 import {
@@ -29,6 +29,21 @@ export const QRCodeBuilder: React.FC = () => {
   const [qrCodeData, setQrCodeData] = useState(qrData)
   // const [editMode, setEditMode] = useState('Templates')
   const debouncedSetQrData = useDebounceCallback(setQrData, 500)
+
+  const handleCopyLink = useCallback(() => {
+    if (typeof window === 'undefined') return
+    const url = new URL(window.location.href)
+    url.searchParams.set('templateId', qrConfig.selectedTemplateId)
+    url.searchParams.set('styleId', qrConfig.selectedStyleId)
+    url.searchParams.set('borderId', qrConfig.selectedBorderId)
+    if (qrConfig.selectedImageId && qrConfig.selectedImageId !== 'none') {
+      url.searchParams.set('image', qrConfig.selectedImageId)
+    } else {
+      url.searchParams.delete('image')
+    }
+    url.searchParams.set('textTemplateId', qrConfig.selectedTextTemplateId)
+    void navigator.clipboard.writeText(url.toString())
+  }, [qrConfig])
 
   useEffect(() => {
     debouncedSetQrData(qrCodeData)
@@ -223,6 +238,14 @@ export const QRCodeBuilder: React.FC = () => {
                     color="primary"
                   >
                     Random All
+                  </Button>
+                  <Button
+                    onPress={handleCopyLink}
+                    startContent={<LinkIcon className="w-4 h-4" />}
+                    variant="ghost"
+                    color="primary"
+                  >
+                    Copy Link
                   </Button>
                   <Button
                     onPress={qrConfig.resetAllTemplates}

--- a/packages/demo/src/context/qr-code-context.tsx
+++ b/packages/demo/src/context/qr-code-context.tsx
@@ -8,83 +8,12 @@ export const UrlSyncHandler: React.FC = () => {
   const qrConfig = useAtomValue(qrConfigAtom)
 
   const {
-    selectedTemplateId,
-    selectedStyleId,
-    selectedBorderId,
-    selectedImageId,
-    selectedTextTemplateId,
-    isAdvancedMode, // Ensure URL params are cleared if in advanced mode
     setSelectedTemplateId,
     setSelectedStyleId,
     setSelectedBorderId,
     setSelectedImageId,
     setSelectedTextTemplateId
   } = qrConfig
-
-  // Update URL parameters without reloading
-  const updateUrlParams = () => {
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href)
-
-      // Clear simple mode params if in advanced mode
-      if (isAdvancedMode) {
-        url.searchParams.delete('templateId')
-        url.searchParams.delete('styleId')
-        url.searchParams.delete('borderId')
-        url.searchParams.delete('image')
-        url.searchParams.delete('textTemplateId')
-      } else {
-        if (selectedTemplateId) {
-          url.searchParams.set('templateId', selectedTemplateId)
-        } else {
-          url.searchParams.delete('templateId')
-        }
-
-        if (selectedStyleId) {
-          url.searchParams.set('styleId', selectedStyleId)
-        } else {
-          url.searchParams.delete('styleId')
-        }
-
-        if (selectedBorderId) {
-          url.searchParams.set('borderId', selectedBorderId)
-        } else {
-          url.searchParams.delete('borderId')
-        }
-
-        if (selectedImageId && selectedImageId !== 'none') {
-          url.searchParams.set('image', selectedImageId)
-        } else {
-          url.searchParams.delete('image')
-        }
-
-        if (selectedTextTemplateId) {
-          url.searchParams.set('textTemplateId', selectedTextTemplateId)
-        } else {
-          url.searchParams.delete('textTemplateId')
-        }
-      }
-
-      // Use pushState to change URL without reload
-      if (window.history && window.history.pushState) {
-        if (url.href !== window.location.href) {
-          window.history.pushState({}, '', url)
-        }
-      }
-    }
-  }
-
-  // Update URL when relevant simple mode selections change
-  useEffect(() => {
-    updateUrlParams()
-  }, [
-    selectedTemplateId,
-    selectedStyleId,
-    selectedBorderId,
-    selectedImageId,
-    selectedTextTemplateId,
-    isAdvancedMode
-  ])
 
   // Initialize state from URL on first render
   useEffect(() => {

--- a/packages/demo/src/store/qrConfigStore.ts
+++ b/packages/demo/src/store/qrConfigStore.ts
@@ -9,6 +9,7 @@ import {
 } from '@qr-platform/qr-code.js'
 import { atomWithStore } from 'jotai-zustand'
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 import { imageOptions } from '../data/qr-data'
 import {
@@ -202,7 +203,7 @@ const initialTextTemplateId = templatesData.textTemplates[0]?.id || 'scan-me'
 const initialImageId = imageOptions[0]?.id || 'none'
 const initialImage = undefined
 
-export const useQrConfigStore = create<QRConfigState>((set, get) => {
+const createQrConfigStore = (set: any, get: any): QRConfigState => {
   // Helper function for circular navigation
   const getNextPrevId = (
     currentId: string,
@@ -725,6 +726,10 @@ export const useQrConfigStore = create<QRConfigState>((set, get) => {
     },
     setActiveGalleryTabId: tabId => set({ activeGalleryTabId: tabId })
   }
-})
+}
+
+export const useQrConfigStore = create<QRConfigState>()(
+  persist(createQrConfigStore, { name: 'qr-config-storage' })
+)
 
 export const qrConfigAtom = atomWithStore(useQrConfigStore)


### PR DESCRIPTION
## Summary
- persist QR configuration using zustand's `persist` middleware
- simplify `UrlSyncHandler` so it only loads state from the URL
- add "Copy Link" button in the builder for sharing state

## Testing
- `npm --prefix packages/demo run lint`