### PR TITLE
Fix double QR code preview rendering

### DIFF
--- a/packages/demo/src/components/qr-code-preview.tsx
+++ b/packages/demo/src/components/qr-code-preview.tsx
@@ -56,7 +56,7 @@ export const QRCodePreview: React.FC = () => {
     }
 
     setIsQrVisible(false)
-    await new Promise(resolve => setTimeout(resolve, 1300)) // For fade effect
+    await new Promise(resolve => setTimeout(resolve, 300)) // For fade effect
 
     setIsLoading(true)
     setIsValid(null)

--- a/packages/demo/src/components/qr-code-preview.tsx
+++ b/packages/demo/src/components/qr-code-preview.tsx
@@ -30,6 +30,7 @@ export const QRCodePreview: React.FC = () => {
   const [isValidating, setIsValidating] = React.useState(false)
   const [isValid, setIsValid] = React.useState<boolean | null>(null)
   const qrContainerRef = React.useRef<HTMLDivElement>(null)
+  const generationIdRef = React.useRef(0)
   const [isQrVisible, setIsQrVisible] = React.useState(true) // For fade animation
   const validationTimerRef = React.useRef<number | null>(null) // Changed NodeJS.Timeout to number
 
@@ -59,6 +60,8 @@ export const QRCodePreview: React.FC = () => {
 
     setIsLoading(true)
     setIsValid(null)
+
+    const localGenerationId = ++generationIdRef.current
 
     console.log('generateQRCodeAsync')
 
@@ -106,7 +109,8 @@ export const QRCodePreview: React.FC = () => {
             image: null,
             text: null,
             textId: null,
-            options: optionsForLib
+            options: optionsForLib,
+            generationId: localGenerationId
           })
           generationAttempted = true
         } else {
@@ -126,7 +130,8 @@ export const QRCodePreview: React.FC = () => {
             image: currentSelectedImage,
             text: null,
             textId: currentSelectedTextTemplateId,
-            options: { isResponsive: true }
+            options: { isResponsive: true },
+            generationId: localGenerationId
           })
           generationAttempted = true
         } else {

--- a/packages/demo/src/services/qr-code-service.ts
+++ b/packages/demo/src/services/qr-code-service.ts
@@ -20,6 +20,7 @@ interface GenerateQRCodeOptions {
   border?: string | null
   options?: QRCodeJsOptions
   isPreview?: boolean
+  generationId?: number
 }
 
 // Token for authentication
@@ -32,6 +33,8 @@ export class QRCodeService {
   private isInitialized = false
   private qrPreview: QRCodeJsLib | null = null
   private qrGallery: QRCodeJsLib | null = null
+  private previewGenerationId = 0
+  private galleryGenerationId = 0
 
   private constructor() {}
 
@@ -114,7 +117,8 @@ export class QRCodeService {
     text,
     textId,
     options,
-    isPreview = true
+    isPreview = true,
+    generationId
   }: GenerateQRCodeOptions): Promise<boolean> {
     if (!element) {
       return false
@@ -185,7 +189,21 @@ export class QRCodeService {
         element.innerHTML = ''
       }
 
+      const currentId =
+        generationId ??
+        (isPreview ? ++this.previewGenerationId : ++this.galleryGenerationId)
+
+      if (isPreview) {
+        this.previewGenerationId = currentId
+      } else {
+        this.galleryGenerationId = currentId
+      }
+
       requestAnimationFrame(async () => {
+        const latestId = isPreview ? this.previewGenerationId : this.galleryGenerationId
+        if (currentId !== latestId) {
+          return
+        }
         const qrInstance = QRCodeJsLib.useSettings(qrCodeSettings).build()
 
         if (

--- a/packages/demo/src/services/qr-code-service.ts
+++ b/packages/demo/src/services/qr-code-service.ts
@@ -204,7 +204,7 @@ export class QRCodeService {
         if (currentId !== latestId) {
           return
         }
-        const qrInstance = QRCodeJsLib.useSettings(qrCodeSettings).build()
+        const qrInstance = await QRCodeJsLib.useSettings(qrCodeSettings).build()
 
         if (
           !(isPreview ? (this.qrPreview = qrInstance) : (this.qrGallery = qrInstance))
@@ -212,7 +212,7 @@ export class QRCodeService {
           throw new Error('Failed to create QR code instance')
         }
 
-        await qrInstance.append(element)
+        await qrInstance.append(element, { clearContainer: true })
       })
 
       return true


### PR DESCRIPTION
## Summary
- add generationId check in qr-code service to avoid outdated renders
- track generation id in `QR code preview` component
- pass generationId to QR code generation calls

## Testing
- `npm run lint`