### PR TITLE
Enable advanced customization builder

### DIFF
--- a/packages/demo/src/components/advanced-customization.tsx
+++ b/packages/demo/src/components/advanced-customization.tsx
@@ -20,12 +20,15 @@ import {
   CornerSquareType,
   DotType,
   ErrorCorrectionLevel,
+  ImageMode,
+  Mode,
   ShapeType
 } from '@qr-platform/qr-code.js'
 import { useAtomValue } from 'jotai'
 import { LinkIcon } from 'lucide-react'
 
 import { qrConfigAtom } from '../store'
+import { BorderCustomization } from './border-customization'
 import GradientEditor from './ui/GradientEditor'
 
 export const AdvancedCustomization: React.FC = () => {
@@ -195,7 +198,6 @@ export const AdvancedCustomization: React.FC = () => {
                 ]}
               />
             </div>
-            {/* TODO: Add controls for qrOptions.typeNumber and qrOptions.mode */}
             <Input
               type="number"
               label="QR Type Number (0 for auto)"
@@ -207,7 +209,23 @@ export const AdvancedCustomization: React.FC = () => {
               min="0"
               max="40"
             />
-            {/* Consider Select for qrOptions.mode if it's an enum */}
+            <Select
+              label="Encoding Mode"
+              selectedKeys={
+                advancedOptions.qrOptions?.mode ? [advancedOptions.qrOptions.mode] : []
+              }
+              onSelectionChange={keys => {
+                const selected = Array.from(keys)[0] as any
+                handleQrOptionChange('mode', selected)
+              }}
+              variant="bordered"
+            >
+              {Object.values(Mode).map(m => (
+                <SelectItem key={m} textValue={m}>
+                  {m.charAt(0).toUpperCase() + m.slice(1)}
+                </SelectItem>
+              ))}
+            </Select>
           </div>
         </Tab>
 
@@ -417,19 +435,99 @@ export const AdvancedCustomization: React.FC = () => {
                 }
                 variant="bordered"
               />
-              {/* TODO: Add more image options: mode, imageSize, margin, crossOrigin, fill */}
-              <p className="text-sm text-default-500">
-                More image options (size, margin, etc.) coming soon.
-              </p>
+              <Select
+                label="Image Mode"
+                selectedKeys={
+                  advancedOptions.imageOptions?.mode
+                    ? [advancedOptions.imageOptions.mode]
+                    : []
+                }
+                onSelectionChange={keys => {
+                  const selected = Array.from(keys)[0] as ImageMode | undefined
+                  if (selected) qrConfig.setAdvancedImageOption?.('mode', selected)
+                }}
+                variant="bordered"
+              >
+                {Object.values(ImageMode).map(m => (
+                  <SelectItem key={m} textValue={m}>
+                    {m.charAt(0).toUpperCase() + m.slice(1)}
+                  </SelectItem>
+                ))}
+              </Select>
+
+              <div>
+                <p className="text-sm mb-2">Image Size</p>
+                <Slider
+                  size="sm"
+                  step={0.05}
+                  minValue={0.1}
+                  maxValue={1}
+                  value={advancedOptions.imageOptions?.imageSize || 0.4}
+                  onChange={v =>
+                    qrConfig.setAdvancedImageOption?.(
+                      'imageSize',
+                      typeof v === 'number' ? v : 0.4
+                    )
+                  }
+                  className="max-w-md"
+                />
+              </div>
+
+              <div>
+                <p className="text-sm mb-2">Image Margin</p>
+                <Slider
+                  size="sm"
+                  step={1}
+                  minValue={0}
+                  maxValue={20}
+                  value={advancedOptions.imageOptions?.margin || 0}
+                  onChange={v =>
+                    qrConfig.setAdvancedImageOption?.(
+                      'margin',
+                      typeof v === 'number' ? v : 0
+                    )
+                  }
+                  className="max-w-md"
+                />
+              </div>
+
+              <Input
+                label="Cross Origin"
+                placeholder="anonymous"
+                value={advancedOptions.imageOptions?.crossOrigin || ''}
+                onValueChange={val =>
+                  qrConfig.setAdvancedImageOption?.('crossOrigin', val)
+                }
+                variant="bordered"
+              />
+
+              <GradientEditor
+                label="Image Fill"
+                value={
+                  advancedOptions.imageOptions?.fill?.gradient ||
+                  advancedOptions.imageOptions?.fill?.color ||
+                  'rgba(255,255,255,1)'
+                }
+                onChange={val => {
+                  if (typeof val === 'string') {
+                    qrConfig.setAdvancedImageOption?.('fill', { color: val })
+                  } else {
+                    qrConfig.setAdvancedImageOption?.('fill', { gradient: val })
+                  }
+                }}
+              />
             </div>
           </div>
         </Tab>
         <Tab key="borders" title="Borders">
           <div className="pt-4">
-            {/* TODO: Implement Border Options UI here from BorderCustomization.tsx or similar */}
-            <p className="text-default-500">
-              Full border customization options will be implemented here.
-            </p>
+            <BorderCustomization
+              borderOptions={advancedOptions.borderOptions}
+              updateBorderOption={(path, value) =>
+                qrConfig.setAdvancedBorderOption &&
+                qrConfig.setAdvancedBorderOption(path as any, value)
+              }
+            />
           </div>
         </Tab>
         <Tab key="presets" title="Presets Management">

--- a/packages/demo/src/components/qr-code-builder.tsx
+++ b/packages/demo/src/components/qr-code-builder.tsx
@@ -64,6 +64,9 @@ export const QRCodeBuilder: React.FC = () => {
                   size="lg"
                   variant="solid"
                   onSelectionChange={selectedMode => {
+                    if (selectedMode === 'Advanced') {
+                      qrConfig.applyTemplatesToAdvancedOptions?.()
+                    }
                     setEditMode(selectedMode as string)
                   }}
                 >
@@ -78,11 +81,10 @@ export const QRCodeBuilder: React.FC = () => {
                   />
                   <Tab
                     key="Advanced"
-                    disabled
                     title={
                       <div className="flex items-center space-x-2">
                         <Settings className="text-default-400 w-4 h-4" />
-                        <span>Advanced (Soon)</span>
+                        <span>Advanced</span>
                       </div>
                     }
                   />

--- a/packages/demo/src/components/qr-code-preview.tsx
+++ b/packages/demo/src/components/qr-code-preview.tsx
@@ -140,7 +140,7 @@ export const QRCodePreview: React.FC = () => {
           ...(currentAdvancedOptions as any),
           data: currentQrData
         }
-        textIdForService = null // Advanced mode typically defines text within options
+        textIdForService = currentSelectedTextTemplateIdFromConfig
 
         if (currentConfigIsCustomTextOverrideEnabled) {
           const decorations: any = {}
@@ -176,6 +176,7 @@ export const QRCodePreview: React.FC = () => {
           // Removed: if (finalOptionsForService.text) finalOptionsForService.text = null
           if ((finalOptionsForService as any).textId)
             (finalOptionsForService as any).textId = null
+          textIdForService = null
         }
       } else {
         // Simple Mode
@@ -221,13 +222,13 @@ export const QRCodePreview: React.FC = () => {
         generationSuccess = await qrCodeService.generateQRCode({
           element: container,
           data: currentQrData,
-          templateId: currentConfigIsAdvancedMode ? null : currentSelectedTemplateId,
+          templateId: currentSelectedTemplateId,
           template: null,
-          styleId: currentConfigIsAdvancedMode ? null : currentSelectedStyleId,
-          borderId: currentConfigIsAdvancedMode ? null : currentSelectedBorderId,
+          styleId: currentSelectedStyleId,
+          borderId: currentSelectedBorderId,
           style: null,
-          image: currentConfigIsAdvancedMode ? null : currentSelectedImage,
-          text: null, // Text object is not used directly by service when textId or borderOptions.decorations are primary
+          image: currentSelectedImage,
+          text: null,
           textId: textIdForService,
           options: finalOptionsForService
         })

--- a/packages/demo/src/components/template-gallery.tsx
+++ b/packages/demo/src/components/template-gallery.tsx
@@ -173,7 +173,7 @@ export const TemplateGallery: React.FC = () => {
               ? null
               : imageOptions.find(img => img.id === deferredImageId)?.value || null
 
-          const options = {
+          const options: any = {
             element: el,
             data: deferredQrData,
             templateId: deferredTemplateId,
@@ -181,7 +181,47 @@ export const TemplateGallery: React.FC = () => {
             borderId: deferredBorderId,
             image: baseImage,
             textId: deferredTextTemplateId,
-            options: { isResponsive: false }
+            options: _isAdvancedMode
+              ? { ..._advancedOptions, isResponsive: false }
+              : { isResponsive: false }
+          }
+
+          if (
+            _isAdvancedMode &&
+            _advancedOptions &&
+            _advancedOptions.borderOptions &&
+            qrConfigStoreState.isCustomTextOverrideEnabled
+          ) {
+            const decorations: any = {}
+            const sides: Array<'top' | 'bottom' | 'left' | 'right'> = [
+              'top',
+              'bottom',
+              'left',
+              'right'
+            ]
+            sides.forEach(side => {
+              const textValue =
+                qrConfigStoreState.customTextOverrides[side] ||
+                qrConfigStoreState.customTextOverrides.all
+              if (textValue) {
+                const existingDecoration =
+                  _advancedOptions.borderOptions?.decorations?.[side]
+                decorations[side] = {
+                  ...existingDecoration,
+                  enableText: true,
+                  type: 'text',
+                  value: textValue
+                }
+              } else {
+                decorations[side] = { enableText: false }
+              }
+            })
+            options.options.borderOptions = {
+              ...(options.options.borderOptions || {}),
+              decorations,
+              hasBorder: true
+            }
+            options.textId = null
           }
 
           switch (activeGalleryTabId) {
@@ -230,7 +270,11 @@ export const TemplateGallery: React.FC = () => {
     deferredStyleId,
     deferredImageId,
     deferredTextTemplateId,
-    activeCategory
+    activeCategory,
+    _isAdvancedMode,
+    _advancedOptions,
+    qrConfigStoreState.isCustomTextOverrideEnabled,
+    qrConfigStoreState.customTextOverrides
   ])
 
   const handleTemplateSelect = (item: any) => {

--- a/packages/demo/src/components/ui/CustomTextControls.tsx
+++ b/packages/demo/src/components/ui/CustomTextControls.tsx
@@ -85,7 +85,9 @@ export const CustomTextControls: React.FC = () => {
 
   const updateDecorationSetting = (key: string, value: any) => {
     const { advancedOptions: currentAdvancedOptions } = useQrConfigStore.getState()
-    const currentBorderOptions = { ...currentAdvancedOptions.borderOptions }
+    const currentBorderOptions = structuredClone(
+      currentAdvancedOptions.borderOptions || {}
+    )
 
     if (!currentBorderOptions.decorations) {
       currentBorderOptions.decorations = {}
@@ -146,7 +148,9 @@ export const CustomTextControls: React.FC = () => {
 
   const resetCurrentSideSettings = () => {
     const { advancedOptions: currentAdvancedOptions } = useQrConfigStore.getState()
-    const currentBorderOptions = { ...currentAdvancedOptions.borderOptions }
+    const currentBorderOptions = structuredClone(
+      currentAdvancedOptions.borderOptions || {}
+    )
 
     if (!currentBorderOptions.decorations) {
       return


### PR DESCRIPTION
## Summary
- enable Advanced tab in builder and populate options from templates
- add QR mode select and full image options
- embed border customization UI
- merge template defaults into advanced options when switching modes
- apply advanced overrides to preview and gallery
- improve custom text controls

## Testing
- `npm run format`
- `npm run lint`